### PR TITLE
Background color

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,11 @@ export var schema = {
     type: 'boolean',
     default: true,
   },
+  backgroundColor: {
+    type: 'string',
+    description: 'Change the default background color of the codeglance view. The default uses the color from your current theme.',
+    default: 'theme',
+  },
   codeHighlighting: {
     description: 'Might be heavy on performance, especially with large files.',
     type: 'boolean',
@@ -38,6 +43,9 @@ export default {
   },
   get showLineNumbers() {
     return atom.config.get('minimap-codeglance.showLineNumbers')
+  },
+  get backgroundColor() {
+    return atom.config.get('minimap-codeglance.backgroundColor')
   },
   get codeHighlighting() {
     return atom.config.get('minimap-codeglance.codeHighlighting')

--- a/lib/minimap-codeglance-element.js
+++ b/lib/minimap-codeglance-element.js
@@ -69,6 +69,19 @@ const prototype = Object.create(HTMLElement.prototype, makePropertyDescriptors({
     this.style.height = `${config.numberOfLines * lineHeight}px`
   },
 
+  setBackgroundColor(backgroundColor) {
+    if (backgroundColor) {
+      if (backgroundColor === 'theme') {
+        const workspace = document.getElementsByTagName('atom-workspace')
+        const style = window.getComputedStyle(workspace[0])
+        backgroundColor = style.getPropertyValue('background-color')
+      }
+      Object.assign(this.style, {
+        'backgroundColor': backgroundColor,
+      })
+    }
+  },
+
   showLineNumbers(showLineNumbers) {
     var lineNumbersView = atom.views.getView(this.lineNumbers)
     if(!lineNumbersView) return

--- a/lib/minimap-codeglance.js
+++ b/lib/minimap-codeglance.js
@@ -12,6 +12,9 @@ var prototype = {
       atom.config.observe('minimap-codeglance.showLineNumbers', showLineNumbers =>
         this.element.showLineNumbers(showLineNumbers)
       ),
+      atom.config.observe('minimap-codeglance.backgroundColor', backgroundColor =>
+        this.element.setBackgroundColor(backgroundColor)
+      ),
       atom.config.observe('minimap.displayMinimapOnLeft', showOnLeft =>
         this.updatePosition(showOnLeft)
       ),


### PR DESCRIPTION
Awesome Atom plugin! One thing I noticed when using it in conjunction with the [editor-background ](https://atom.io/packages/editor-background) package was the difficulty to read the text in the codeglance view. To remedy this, I could have just added a background color in my style  config. However, I wanted the background to grab the color of the current theme I was using. That way, if I changed themes, the background color would change as well.

This is what I was seeing 👀
<img width="1708" alt="bug" src="https://cloud.githubusercontent.com/assets/11774595/17386563/fd2e31a2-59b9-11e6-9665-8653c4103da4.png">

This is what it looks like now 👍🏼
<img width="1495" alt="fixed" src="https://cloud.githubusercontent.com/assets/11774595/17386567/07b31868-59ba-11e6-8f14-e3730a6f04ba.png">

Here is the added background config option 🛠
<img width="1310" alt="config" src="https://cloud.githubusercontent.com/assets/11774595/17386572/0e841e3a-59ba-11e6-9d89-9c3693ea2693.png">

I won't be upset if you choose not to accept, but I liked my additions and use them personally. Thought others using your package might like it as well.
