### PR TITLE
Removed deprecated ::shadow selector

### DIFF
--- a/styles/minimap-codeglance.atom-text-editor.less
+++ b/styles/minimap-codeglance.atom-text-editor.less
@@ -23,14 +23,12 @@ minimap-codeglance {
     width: 100%;
     height: 100%;
 
-    &::shadow {
-      // hide the cursor and the scrollbar
-      // because they are irrelevant in
-      // the codeglance view
-      .cursor,
-      ::-webkit-scrollbar {
-        display: none;
-      }
+    // hide the cursor and the scrollbar
+    // because they are irrelevant in
+    // the codeglance view
+    .cursor,
+    ::-webkit-scrollbar {
+      display: none;
     }
   }
 }

--- a/styles/minimap-codeglance.atom-text-editor.less
+++ b/styles/minimap-codeglance.atom-text-editor.less
@@ -26,9 +26,11 @@ minimap-codeglance {
     // hide the cursor and the scrollbar
     // because they are irrelevant in
     // the codeglance view
-    .cursor,
-    ::-webkit-scrollbar {
-      display: none;
+    &.editor {
+      .cursor,
+      ::-webkit-scrollbar {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
Just a small edit to keep up to date with the deprecation of the ::shadow selector.