### PR TITLE
explicitly disable autoHeight to address issue #31

### DIFF
--- a/lib/minimap-codeglance-element.js
+++ b/lib/minimap-codeglance-element.js
@@ -20,6 +20,7 @@ function buildTextEditor() {
 const prototype = Object.create(HTMLElement.prototype, makePropertyDescriptors({
   createdCallback() {
     this.lines = buildTextEditor()
+    this.lines.autoHeight = false
     this.linesView = atom.views.getView(this.lines)
     this.appendChild(this.linesView)
 


### PR DESCRIPTION
Per issue #31: Atom is deprecating the “implicit disabling autoHeight” feature thus
created “package deprecated” warning for minimal-codeglance at startup.
This fix explicitly set the autoHeight to false when the editor first
created to eliminate the deprecation warning.